### PR TITLE
Support numeric strings in Scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Features
 
-- 🎯 One generic `Nullable[T]` works with any type
+- 🎯 One generic `Nullable[T]` works with **any** type
 - 💡 Omitzero support
 - 🔄 Built-in JSON marshaling/unmarshaling
 - 📊 SQL database compatibility

--- a/README.md
+++ b/README.md
@@ -94,3 +94,11 @@ func main() {
     // ...
 }
 ```
+
+## Contribution
+
+<a href="https://github.com/LukaGiorgadze/gonull/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=LukaGiorgadze/gonull" />
+</a>
+
+Made with [contrib.rocks](https://contrib.rocks).

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - 💡 Omitzero support
 - 🔄 Built-in JSON marshaling/unmarshaling
 - 📊 SQL database compatibility
+- 🔢 Handles numeric values returned as strings by SQL drivers
 - ✨ Zero dependencies
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -8,12 +8,28 @@
 
 ## Features
 
-- 🎯 Type-safe nullable values using Go generics
+- 🎯 One generic `Nullable[T]` works with any type
 - 💡 Omitzero support
 - 🔄 Built-in JSON marshaling/unmarshaling
 - 📊 SQL database compatibility
 - 🔢 Handles numeric values returned as strings by SQL drivers
+- 🧩 Works seamlessly with your own alias or enum types
 - ✨ Zero dependencies
+
+### Why gonull?
+
+`Nullable[T]` keeps your code concise by using Go generics for any type. You don't need separate wrappers for strings, ints or custom enumerations. Built-in `sql.Scanner` and `json` support make it easy to integrate with databases and APIs.
+
+```go
+type Status string
+
+type Task struct {
+    ID    int
+    State gonull.Nullable[Status]
+}
+```
+
+---
 
 ## Usage
 
@@ -21,7 +37,7 @@
 go get github.com/LukaGiorgadze/gonull/v2
 ```
 
-### Example
+### Example #1
 
 ```go
 package main
@@ -67,7 +83,7 @@ func main() {
 }
 ```
 
-### Database example
+### Example #2
 
 ```go
 type User struct {

--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ func main() {
 }
 ```
 
+### Explore More Examples
+See [./examples](./examples) directory.
+
 ## Contribution
 
 <a href="https://github.com/LukaGiorgadze/gonull/graphs/contributors">

--- a/gonull_test.go
+++ b/gonull_test.go
@@ -838,6 +838,12 @@ func TestNullableScan_Float64(t *testing.T) {
 			Present:  true,
 		},
 		{
+			name:    "invalid string",
+			value:   "foo",
+			wantErr: true,
+			Present: true,
+		},
+		{
 			name:    "[]uint8|[]byte type empty",
 			value:   []byte{},
 			wantErr: true,
@@ -891,6 +897,35 @@ func TestNullableScan_IntFromString(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var n Nullable[int]
+			err := n.Scan(tt.value)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.True(t, n.Valid)
+				assert.True(t, n.Present)
+				assert.Equal(t, tt.want, n.Val)
+			}
+		})
+	}
+}
+
+func TestNullableScan_UintFromString(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   any
+		want    uint
+		wantErr bool
+	}{
+		{name: "valid string", value: "42", want: 42},
+		{name: "invalid string", value: "bar", wantErr: true},
+		{name: "empty string", value: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var n Nullable[uint]
 			err := n.Scan(tt.value)
 
 			if tt.wantErr {

--- a/gonull_test.go
+++ b/gonull_test.go
@@ -175,6 +175,13 @@ func TestNullableScan_Float(t *testing.T) {
 			Present:  true,
 		},
 		{
+			name:     "string type",
+			value:    "0.25",
+			expected: float32(0.25),
+			Valid:    true,
+			Present:  true,
+		},
+		{
 			name:     "[]uint8|[]byte type",
 			value:    []byte{48, 46, 50, 53},
 			expected: float32(0.25),
@@ -817,6 +824,13 @@ func TestNullableScan_Float64(t *testing.T) {
 			Present:  true,
 		},
 		{
+			name:     "string type",
+			value:    "0.25",
+			expected: float64(0.25),
+			Valid:    true,
+			Present:  true,
+		},
+		{
 			name:     "[]uint8|[]byte type",
 			value:    []byte("0.25"),
 			expected: float64(0.25),
@@ -857,6 +871,35 @@ func TestNullableScan_Float64(t *testing.T) {
 				if tt.Valid {
 					assert.Equal(t, tt.expected, n.Val)
 				}
+			}
+		})
+	}
+}
+
+func TestNullableScan_IntFromString(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   any
+		want    int
+		wantErr bool
+	}{
+		{name: "valid string", value: "42", want: 42},
+		{name: "invalid string", value: "foo", wantErr: true},
+		{name: "empty string", value: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var n Nullable[int]
+			err := n.Scan(tt.value)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.True(t, n.Valid)
+				assert.True(t, n.Present)
+				assert.Equal(t, tt.want, n.Val)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- handle numeric string inputs in `convertToType`
- test scanning floats from strings
- test scanning ints from strings
- document numeric-string support in README

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6843d3e5aeb88328803fe1b2e0e57082