### PR TITLE
docs: Auto-translate README and Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,34 @@
+
+<div align="right">
+  <details>
+    <summary >🌐 Language</summary>
+    <div>
+      <div align="center">
+        <a href="https://openaitx.github.io/view.html?user=LukaGiorgadze&project=gonull&lang=en">English</a>
+        | <a href="https://openaitx.github.io/view.html?user=LukaGiorgadze&project=gonull&lang=zh-CN">简体中文</a>
+        | <a href="https://openaitx.github.io/view.html?user=LukaGiorgadze&project=gonull&lang=zh-TW">繁體中文</a>
+        | <a href="https://openaitx.github.io/view.html?user=LukaGiorgadze&project=gonull&lang=ja">日本語</a>
+        | <a href="https://openaitx.github.io/view.html?user=LukaGiorgadze&project=gonull&lang=ko">한국어</a>
+        | <a href="https://openaitx.github.io/view.html?user=LukaGiorgadze&project=gonull&lang=hi">हिन्दी</a>
+        | <a href="https://openaitx.github.io/view.html?user=LukaGiorgadze&project=gonull&lang=th">ไทย</a>
+        | <a href="https://openaitx.github.io/view.html?user=LukaGiorgadze&project=gonull&lang=fr">Français</a>
+        | <a href="https://openaitx.github.io/view.html?user=LukaGiorgadze&project=gonull&lang=de">Deutsch</a>
+        | <a href="https://openaitx.github.io/view.html?user=LukaGiorgadze&project=gonull&lang=es">Español</a>
+        | <a href="https://openaitx.github.io/view.html?user=LukaGiorgadze&project=gonull&lang=it">Italiano</a>
+        | <a href="https://openaitx.github.io/view.html?user=LukaGiorgadze&project=gonull&lang=ru">Русский</a>
+        | <a href="https://openaitx.github.io/view.html?user=LukaGiorgadze&project=gonull&lang=pt">Português</a>
+        | <a href="https://openaitx.github.io/view.html?user=LukaGiorgadze&project=gonull&lang=nl">Nederlands</a>
+        | <a href="https://openaitx.github.io/view.html?user=LukaGiorgadze&project=gonull&lang=pl">Polski</a>
+        | <a href="https://openaitx.github.io/view.html?user=LukaGiorgadze&project=gonull&lang=ar">العربية</a>
+        | <a href="https://openaitx.github.io/view.html?user=LukaGiorgadze&project=gonull&lang=fa">فارسی</a>
+        | <a href="https://openaitx.github.io/view.html?user=LukaGiorgadze&project=gonull&lang=tr">Türkçe</a>
+        | <a href="https://openaitx.github.io/view.html?user=LukaGiorgadze&project=gonull&lang=vi">Tiếng Việt</a>
+        | <a href="https://openaitx.github.io/view.html?user=LukaGiorgadze&project=gonull&lang=id">Bahasa Indonesia</a>
+      </div>
+    </div>
+  </details>
+</div>
+
 # Go Nullable with Generics
 
 [![PkgGoDev](https://pkg.go.dev/badge/github.com/LukaGiorgadze/gonull)](https://pkg.go.dev/github.com/LukaGiorgadze/gonull) ![go-mod-verify](https://github.com/LukaGiorgadze/gonull/workflows/Go%20mod/badge.svg) ![go-vuln](https://github.com/LukaGiorgadze/gonull/workflows/Security/badge.svg) ![golangci-lint](https://github.com/LukaGiorgadze/gonull/workflows/Linter/badge.svg) [![codecov](https://codecov.io/gh/LukaGiorgadze/gonull/branch/main/graph/badge.svg?token=76089e7b-f137-4459-8eae-4b48007bd0d6)](https://codecov.io/gh/LukaGiorgadze/gonull) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/LukaGiorgadze/gonull)


### PR DESCRIPTION
Added language badges to the README for easier access to translated versions: German, Spanish, French, Japanese, Korean, Portuguese, and Russian 20 languages.
System will auto-update translation for README and Wiki when this repository updated, and support multiple languages google/bing SEO search.

Demo links : 
- [English](https://openaitx.github.io/view.html?user=LukaGiorgadze&project=gonull&lang=en)
- [简体中文](https://openaitx.github.io/view.html?user=LukaGiorgadze&project=gonull&lang=zh-CN)
- [日本語](https://openaitx.github.io/view.html?user=LukaGiorgadze&project=gonull&lang=ja)
- [한국어](https://openaitx.github.io/view.html?user=LukaGiorgadze&project=gonull&lang=ko)
..


<img width="1178" height="537" alt="Image" src="https://github.com/user-attachments/assets/7cd54a88-59c1-455f-9c7d-2db7f05b2962" />

If this was not your expection, please close this PR. Thank you! 🙌
